### PR TITLE
Share a launch via text

### DIFF
--- a/app/src/main/java/com/example/voyagerx/LaunchDetailsFragment.kt
+++ b/app/src/main/java/com/example/voyagerx/LaunchDetailsFragment.kt
@@ -122,10 +122,10 @@ class LaunchDetailsFragment : Fragment() {
         val share = Intent.createChooser(Intent().apply {
             action = Intent.ACTION_SEND
             putExtra(Intent.EXTRA_TEXT, "Check out this SpaceX Launch!\n\n" +
-                    "${launchObj.mission_name}\n\n" +
-                    "${launchObj.details}\n\n" +
-                    "Watch the launch video:\n" +
-                    "${launchObj.video_link}")
+                    if (!launchObj.mission_name.isNullOrEmpty()) "${launchObj.mission_name}\n\n" else "" +
+                    if (!launchObj.details.isNullOrEmpty()) "${launchObj.details}\n\n" else "" +
+                    if(!launchObj.video_link.isNullOrEmpty()) "Watch the launch video:\n ${launchObj.video_link}" else ""
+            )
             type = "text/plain"
         }, null)
         startActivity(share)

--- a/app/src/main/java/com/example/voyagerx/LaunchDetailsFragment.kt
+++ b/app/src/main/java/com/example/voyagerx/LaunchDetailsFragment.kt
@@ -1,5 +1,6 @@
 package com.example.voyagerx
 
+import android.content.Intent
 import android.os.Bundle
 import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
@@ -7,7 +8,6 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.ImageView
 import androidx.viewpager.widget.ViewPager
-import coil.load
 import com.example.voyagerx.adapters.LaunchCarouselAdapter
 import com.example.voyagerx.databinding.FragmentLaunchDetailsBinding
 import com.example.voyagerx.repository.model.Launch
@@ -51,6 +51,7 @@ class LaunchDetailsFragment : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         displayLaunchDetails()
+        binding.ivShare.setOnClickListener { shareLaunch() }
     }
 
     override fun onDestroyView() {
@@ -115,5 +116,18 @@ class LaunchDetailsFragment : Fragment() {
 
     private fun hideView(view: View) {
         view.visibility = View.GONE
+    }
+
+    private fun shareLaunch() {
+        val share = Intent.createChooser(Intent().apply {
+            action = Intent.ACTION_SEND
+            putExtra(Intent.EXTRA_TEXT, "Check out this SpaceX Launch!\n\n" +
+                    "${launchObj.mission_name}\n\n" +
+                    "${launchObj.details}\n\n" +
+                    "Watch the launch video:\n" +
+                    "${launchObj.video_link}")
+            type = "text/plain"
+        }, null)
+        startActivity(share)
     }
 }

--- a/app/src/main/res/layout/fragment_launch_details.xml
+++ b/app/src/main/res/layout/fragment_launch_details.xml
@@ -79,21 +79,22 @@
                     android:id="@+id/tvSiteName"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:drawableStart="@drawable/ic_baseline_pin_drop_24"
                     android:drawablePadding="@dimen/margin_sm"
                     android:paddingVertical="@dimen/margin_sm"
                     tools:text="@string/sample_site_name_long"
-                    android:textAppearance="@style/TextAppearance.AppCompat.Body1" />
+                    android:textAppearance="@style/TextAppearance.AppCompat.Body1"
+                    app:drawableStartCompat="@drawable/ic_baseline_pin_drop_24" />
 
                 <TextView
                     android:id="@+id/tvLaunchDate"
-                    android:layout_width="match_parent"
+                    android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:layout_marginVertical="@dimen/margin_sm"
-                    android:drawableStart="@drawable/ic_baseline_calendar_today_24"
                     android:drawablePadding="@dimen/margin_sm"
-                    tools:text="@string/sample_launch_date"
-                    android:textAppearance="@style/TextAppearance.AppCompat.Body1" />
+                    android:paddingVertical="@dimen/margin_sm"
+                    tools:text="@string/sample_site_name_long"
+                    android:drawableTint="@color/gray"
+                    android:textAppearance="@style/TextAppearance.AppCompat.Body1"
+                    app:drawableStartCompat="@drawable/ic_baseline_calendar_today_24" />
 
                 <LinearLayout
                     android:id="@+id/llDetailsSection"


### PR DESCRIPTION
Created the method `shareLaunch()` within the launch details fragment. The method creates a text message with launch information. If any field is null, it will be omitted from the text message.

https://user-images.githubusercontent.com/41392379/166403320-dcbd479e-e09c-4f43-b258-020aed71c361.mov

