### PR TITLE
Format Launch Date

### DIFF
--- a/app/src/main/java/com/example/voyagerx/LaunchDetailsFragment.kt
+++ b/app/src/main/java/com/example/voyagerx/LaunchDetailsFragment.kt
@@ -7,9 +7,9 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.ImageView
 import androidx.viewpager.widget.ViewPager
-import coil.load
 import com.example.voyagerx.adapters.LaunchCarouselAdapter
 import com.example.voyagerx.databinding.FragmentLaunchDetailsBinding
+import com.example.voyagerx.helpers.DateFormatter
 import com.example.voyagerx.repository.model.Launch
 
 /**
@@ -88,7 +88,7 @@ class LaunchDetailsFragment : Fragment() {
         }
 
         launchObj.launch_date_utc?.let {
-            binding.tvLaunchDate.text = it
+            binding.tvLaunchDate.text = DateFormatter.formatLaunchDate(launchObj.launch_date_utc)
         } ?: run {
             hideView(binding.tvLaunchDate)
         }

--- a/app/src/main/java/com/example/voyagerx/helpers/DateFormatter.kt
+++ b/app/src/main/java/com/example/voyagerx/helpers/DateFormatter.kt
@@ -1,0 +1,9 @@
+package com.example.voyagerx.helpers
+
+//singleton - we only need one instance of this class
+object DateFormatter {
+    fun formatLaunchDate(launchDateUtc: String?): String? {
+        val pattern = "T.*".toRegex()
+        return launchDateUtc?.replace(pattern, "")
+    }
+}


### PR DESCRIPTION
In order to make the date more readable, I created a helper object to format the `launch_date_utc` field. The helper replaces all characters after the 'T' with a blank character.

`"2020-12-13T17:30:00.000Z"` to `"2020-12-13"`

Jira ticket: https://onramp-training.atlassian.net/browse/TA2-82?atlOrigin=eyJpIjoiMmUxMjIyNDUyYzBkNDE3ZjlhMTE5Zjg3Nzc0ZWE4YTkiLCJwIjoiaiJ9


![Screen Shot 2022-05-03 at 10 10 21 AM](https://user-images.githubusercontent.com/41392379/166482487-ba66d4d7-1f0f-4e0a-823f-cc8d8efa7ad8.png)
