### PR TITLE
get launches from cache

### DIFF
--- a/app/src/androidTest/java/com/example/voyagerx/database/SimpleEntityReadWriteTest.kt
+++ b/app/src/androidTest/java/com/example/voyagerx/database/SimpleEntityReadWriteTest.kt
@@ -6,6 +6,7 @@ import androidx.room.Room
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.espresso.matcher.ViewMatchers.assertThat
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.example.voyagerx.repository.database.LaunchDao
 import com.example.voyagerx.repository.database.UserDao
 import com.example.voyagerx.repository.database.VoyagerXDatabase
 import com.example.voyagerx.repository.model.Launch
@@ -23,6 +24,7 @@ import kotlin.jvm.Throws
 class SimpleEntityReadWriteTest {
 
     private lateinit var userDao: UserDao
+    private lateinit var launchDao: LaunchDao
     private lateinit var db: VoyagerXDatabase
 
     @Before
@@ -31,6 +33,7 @@ class SimpleEntityReadWriteTest {
         db = Room.inMemoryDatabaseBuilder(
             context, VoyagerXDatabase::class.java).build()
         userDao = db.userDao()
+        launchDao = db.launchDao()
         Log.d("db", "running")
     }
 
@@ -62,9 +65,9 @@ class SimpleEntityReadWriteTest {
 
         // adding launch to user's favorites
         val newLaunches = mutableListOf<Launch>()
-        byEmail.favoriteLaunches?.let { newLaunches.addAll(it) }
+        byEmail?.favoriteLaunches?.let { newLaunches.addAll(it) }
         newLaunches.add(launch)
-        userDao.updateUserFavoriteLaunches(byEmail.id, newLaunches)
+        userDao.updateUserFavoriteLaunches(byEmail?.id ?: 1, newLaunches)
 
         // assert db's user equal to test user
         val newByEmail = userDao.findUserByEmail("test email")
@@ -76,6 +79,18 @@ class SimpleEntityReadWriteTest {
     fun readEmptyUser(){
         val user = userDao.findUserByEmail("test email")
         assertThat(user, equalTo(null))
+    }
+
+    @Test
+    @Throws(Exception::class)
+    fun addLaunchesAndGetAll(){
+        val launch = Launch("1", null, null, null, null, null, null, null, null)
+        val launch2 = Launch("2", null, null, null, null, null, null, null, null)
+        val listOfLaunches = listOf(launch, launch2)
+        launchDao.insertAll(listOf(launch, launch2))
+        val fromDb = launchDao.getAll()
+
+        assertThat(fromDb, equalTo(listOfLaunches))
     }
 
 }

--- a/app/src/main/java/com/example/voyagerx/repository/LaunchRepository.kt
+++ b/app/src/main/java/com/example/voyagerx/repository/LaunchRepository.kt
@@ -1,9 +1,17 @@
 package com.example.voyagerx.repository
 
+import android.content.Context
+import android.content.SharedPreferences
 import android.util.Log
 import com.example.rocketreserver.LaunchListQuery
+import com.example.voyagerx.R
 import com.example.voyagerx.repository.database.VoyagerXDatabase
 import com.example.voyagerx.repository.model.Launch
+import com.google.gson.Gson
+import com.google.gson.reflect.TypeToken
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.*
+import kotlinx.coroutines.Dispatchers.IO
 import java.util.*
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -11,47 +19,111 @@ import javax.inject.Singleton
 @Singleton
 class LaunchRepository @Inject constructor(
     private val database: VoyagerXDatabase,
-    private val apiService: SpaceXApiService
+    private val apiService: SpaceXApiService,
+    @ApplicationContext private val context: Context
 ){
 
     suspend fun getLaunches() : List<Launch?>? {
-        Log.d("Repository", "attempting to fetch launch data")
+
+        val cachedLaunches = getLaunchesFromCache()
+        if(cachedLaunches != null){
+            Log.d("Repository", "get launch from cache")
+            return cachedLaunches
+        }
+
         return try {
+            Log.d("Repository", "attempting to fetch launch data")
             val apiResult = apiService.getLaunches()
             if (apiResult.isNullOrEmpty()) {
-                null //if we receive empty data
+                //if we receive empty data
+                return getLaunchesFromCache()
             } else {
                 convertLaunches(apiResult) //if we receive launch data
             }
         } catch (exception: Exception) {
-            null //if we receive an error
+            return getLaunchesFromCache()
         }
     }
 
+    private fun getLaunchesFromCache(): List<Launch>?{
+        val sharedPref = getSharedPreferences()
+        return convertJsonToLaunches(sharedPref.getString("cached_launches", null))
+    }
+
 //  convert API result into custom Launch data model
-    private fun convertLaunches(launches: List<LaunchListQuery.Launch?>): List<Launch?> {
+    private fun convertLaunches(launches: List<LaunchListQuery.Launch?>): List<Launch> {
         val customLaunches = launches.map{ launch ->
-            launch?.let {
             Launch(
-                launch.id?: uniqueId(),
-                launch.mission_name,
-                launch.launch_site?.site_name_long,
-                launch.launch_date_utc.toString(),
-                launch.launch_year,
-                launch.details,
-                launch.links?.article_link,
-                launch.links?.video_link,
-                launch.links?.flickr_images
-            )}
+                launch?.id?: uniqueId(),
+                launch?.mission_name,
+                launch?.launch_site?.site_name_long,
+                launch?.launch_date_utc.toString(),
+                launch?.launch_year,
+                launch?.details,
+                launch?.links?.article_link,
+                launch?.links?.video_link,
+                launch?.links?.flickr_images
+            )
         }
+
+        GlobalScope.launch{
+            insertLaunches(customLaunches)
+        }
+        addLaunchesToCache(customLaunches)
         return customLaunches
     }
 
     private fun uniqueId():String = UUID.randomUUID().toString()
 
     //insert launches into launch table
-    private fun insertLaunches(launches: List<Launch>){
-        database.launchDao().insertAll(launches)
+    private suspend fun insertLaunches(launches: List<Launch>){
+        withContext(IO) {
+            database.launchDao().insertAll(launches)
+        }
+    }
+
+    private fun addLaunchesToCache(list: List<Launch>?){
+        val sharedPref = getSharedPreferences()
+        with (sharedPref.edit()) {
+            putString("cached_launches", convertLaunchesToJson(list))
+            apply()
+        }
+    }
+
+    private fun convertLaunchesToJson(list: List<Launch>?): String?{
+        if(list == null){
+            return null
+        }
+
+        val stringListOfLaunch = mutableListOf<String>()
+        val gson = Gson()
+        for(launch in list) {
+            stringListOfLaunch.add(gson.toJson(launch))
+        }
+
+        return gson.toJson(stringListOfLaunch)
+    }
+
+    private fun convertJsonToLaunches(value: String?): List<Launch>?{
+        if(value == null){
+            return null
+        }
+
+        val gson = Gson()
+        val listType = object: TypeToken<List<String>>(){}.type
+        val stringListOfLaunch: List<String> = gson.fromJson(value, listType)
+
+        val listOfLaunch = mutableListOf<Launch>()
+        for(launchString in stringListOfLaunch){
+            listOfLaunch.add(gson.fromJson(launchString, object: TypeToken<Launch>(){}.type))
+        }
+
+        return listOfLaunch
+    }
+
+
+    private fun getSharedPreferences(): SharedPreferences {
+        return context.getSharedPreferences(context.getString(R.string.user_preference), Context.MODE_PRIVATE)
     }
 
 }

--- a/app/src/main/java/com/example/voyagerx/repository/database/LaunchDao.kt
+++ b/app/src/main/java/com/example/voyagerx/repository/database/LaunchDao.kt
@@ -16,7 +16,7 @@ interface LaunchDao {
     fun insertAll(launches: List<Launch>)
 
     @Query("SELECT * FROM Launch")
-    fun getAll(): List<Launch>
+    fun getAll(): List<Launch>?
 
     @Query("SELECT * FROM Launch WHERE id = :id")
     fun findLaunchById(id: String): Launch

--- a/app/src/main/java/com/example/voyagerx/ui/fragments/landing/LandingPageFragment.kt
+++ b/app/src/main/java/com/example/voyagerx/ui/fragments/landing/LandingPageFragment.kt
@@ -17,6 +17,8 @@ import com.example.voyagerx.ui.fragments.landing.list.LaunchOverviewAdapter
 import com.example.voyagerx.helpers.LaunchClickListener
 import com.example.voyagerx.repository.model.Launch
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import javax.inject.Inject
 
 @AndroidEntryPoint
@@ -81,6 +83,7 @@ class LandingPageFragment: Fragment() {
         binding.listing.list.adapter = adapter
 
         viewLifecycleOwner.lifecycleScope.launchWhenResumed {
+
             val result = launchRepository.getLaunches()
             hideSpinner()
 
@@ -92,6 +95,7 @@ class LandingPageFragment: Fragment() {
                 showNetworkError()
             }
         }
+
     }
 
     private fun setListHeaderText(amount: Int) {


### PR DESCRIPTION
Launches will populate from cache if available. I would like some opinions on this though: The current implementation always populates from cache if it is available, but should launches populate from API on app start up instead? 

EDIT: Celina made a slack thread about this.