### PR TITLE
Persist landing page data

### DIFF
--- a/app/src/main/java/com/example/voyagerx/LaunchDetailsFragment.kt
+++ b/app/src/main/java/com/example/voyagerx/LaunchDetailsFragment.kt
@@ -47,19 +47,7 @@ class LaunchDetailsFragment : Fragment() {
         savedInstanceState: Bundle?
     ): View? {
         _binding = FragmentLaunchDetailsBinding.inflate(inflater, container, false)
-
-        launchObj = Launch(
-            arguments?.getString(LaunchDetailFields.id)!!,
-            arguments?.getString(LaunchDetailFields.missionName),
-            arguments?.getString(LaunchDetailFields.launchSite),
-            arguments?.getString(LaunchDetailFields.launchDate),
-            arguments?.getString(LaunchDetailFields.launchYear),
-            arguments?.getString(LaunchDetailFields.details),
-            arguments?.getString(LaunchDetailFields.articleLink),
-            arguments?.getString(LaunchDetailFields.videoLink),
-            arguments?.getStringArray(LaunchDetailFields.imageLinks)?.toList()
-        )
-
+        launchObj = arguments?.getParcelable(Launch.BUNDLE_KEY)!!
         return binding.root
     }
 

--- a/app/src/main/java/com/example/voyagerx/MainActivity.kt
+++ b/app/src/main/java/com/example/voyagerx/MainActivity.kt
@@ -25,6 +25,9 @@ class MainActivity : AppCompatActivity() {
     private lateinit var bottomNavView: BottomNavigationView
     lateinit var binding: ActivityMainBinding
 
+    // use same instance of fragment during the activity lifecycle
+    private val landingPageFragment: LandingPageFragment = LandingPageFragment()
+
     @Inject
     lateinit var userRepository: UserRepository
 
@@ -36,17 +39,21 @@ class MainActivity : AppCompatActivity() {
 
         bottomNavView = binding.bottomNavigationView
 
-        changeFragmentView(LandingPageFragment()) //setting initial view to landing page as you only get here after bypassing login/register screens
+        // don't re-attach the fragment again if onSaveInstanceState was called, otherwise
+        // onViewCreated will be called twice for this fragment
+        // https://stackoverflow.com/questions/10983396/fragment-oncreateview-and-onactivitycreated-called-twice
+        if (savedInstanceState == null) {
+            changeFragmentView(landingPageFragment) //setting initial view to landing page as you only get here after bypassing login/register screens
+        }
 
         bottomNavView.setOnItemSelectedListener {
             when (it.itemId) {
-                R.id.landingPageFragment -> changeFragmentView(LandingPageFragment())
+                R.id.landingPageFragment -> changeFragmentView(landingPageFragment)
                 R.id.profileFragment -> if(userRepository.getCurrentUser() == null) showLoginPopup() else changeFragmentView(ProfileFragment())
                 R.id.settingsFragment -> changeFragmentView(SettingsFragment())
             }
             true
         }
-
 
         setLogInOrLogoutButtonText()
         binding.logInOrOutButton.setOnClickListener {

--- a/app/src/main/java/com/example/voyagerx/MainActivity.kt
+++ b/app/src/main/java/com/example/voyagerx/MainActivity.kt
@@ -40,7 +40,7 @@ class MainActivity : AppCompatActivity() {
         bottomNavView = binding.bottomNavigationView
 
         // don't re-attach the fragment again if onSaveInstanceState was called, otherwise
-        // onViewCreated will be called twice for this fragment
+        // onViewCreated will be called twice for this fragment using an empty bundle
         // https://stackoverflow.com/questions/10983396/fragment-oncreateview-and-onactivitycreated-called-twice
         if (savedInstanceState == null) {
             changeFragmentView(landingPageFragment) //setting initial view to landing page as you only get here after bypassing login/register screens

--- a/app/src/main/java/com/example/voyagerx/repository/model/Launch.kt
+++ b/app/src/main/java/com/example/voyagerx/repository/model/Launch.kt
@@ -1,5 +1,7 @@
 package com.example.voyagerx.repository.model
 
+import android.os.Parcel
+import android.os.Parcelable
 import androidx.room.ColumnInfo
 import androidx.room.Entity
 import androidx.room.PrimaryKey
@@ -18,4 +20,45 @@ data class Launch(
     val article_link: String?,
     val video_link: String?,
     val image_links: List<String?>?
-)
+) : Parcelable {
+
+    constructor(parcel: Parcel) : this(
+        parcel.readString().toString(),
+        parcel.readString(),
+        parcel.readString(),
+        parcel.readString(),
+        parcel.readString(),
+        parcel.readString(),
+        parcel.readString(),
+        parcel.readString(),
+        parcel.createStringArrayList()) {
+    }
+
+    override fun writeToParcel(parcel: Parcel, flags: Int) {
+        parcel.writeString(id)
+        parcel.writeString(mission_name)
+        parcel.writeString(launch_site_long)
+        parcel.writeString(launch_date_utc)
+        parcel.writeString(launch_year)
+        parcel.writeString(details)
+        parcel.writeString(article_link)
+        parcel.writeString(video_link)
+        parcel.writeStringList(image_links)
+    }
+
+    override fun describeContents(): Int {
+        return 0
+    }
+
+    companion object CREATOR : Parcelable.Creator<Launch> {
+        const val BUNDLE_KEY = "launch_details"
+
+        override fun createFromParcel(parcel: Parcel): Launch {
+            return Launch(parcel)
+        }
+
+        override fun newArray(size: Int): Array<Launch?> {
+            return arrayOfNulls(size)
+        }
+    }
+}

--- a/app/src/main/java/com/example/voyagerx/ui/fragments/landing/LandingPageFragment.kt
+++ b/app/src/main/java/com/example/voyagerx/ui/fragments/landing/LandingPageFragment.kt
@@ -4,6 +4,7 @@ import android.annotation.SuppressLint
 import android.content.Context
 import android.graphics.Rect
 import android.os.Bundle
+import android.os.Parcelable
 import android.view.*
 import android.view.inputmethod.InputMethodManager
 import android.widget.EditText
@@ -21,6 +22,7 @@ import com.example.voyagerx.helpers.LaunchClickListener
 import com.example.voyagerx.repository.LaunchRepository
 import com.example.voyagerx.repository.model.Launch
 import com.example.voyagerx.ui.fragments.landing.list.LaunchOverviewAdapter
+import com.example.voyagerx.util.SharedPreferencesManager
 import com.google.android.material.chip.Chip
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
@@ -32,9 +34,15 @@ class LandingPageFragment : Fragment() {
     @Inject
     lateinit var launchRepository: LaunchRepository
 
+    private val SharedPreferencesManager by lazy { SharedPreferencesManager(requireContext()) }
+
     private lateinit var binding: FragmentLandingPageBinding
     private lateinit var launches: List<Launch>
     private lateinit var adapter: LaunchOverviewAdapter
+
+    companion object {
+        const val RECYCLER_VIEW_BUNDLE_KEY =  "launches_recycler_view"
+    }
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -47,12 +55,77 @@ class LandingPageFragment : Fragment() {
         return binding.root
     }
 
+    override fun onSaveInstanceState(outState: Bundle) {
+        outState.putParcelable(RECYCLER_VIEW_BUNDLE_KEY, binding.listing.list.layoutManager?.onSaveInstanceState())
+        super.onSaveInstanceState(outState)
+    }
+
+    override fun onPause() {
+        SharedPreferencesManager.setListingFilterSetting(false, adapter.filtersAllMatch)
+        SharedPreferencesManager.setListingFilterSetting(true, adapter.filtersAnyMatch)
+        super.onPause()
+    }
+
+    // this will restore the list position during orientation changes/after navigation
+    private fun restoreRecyclerViewState(savedInstanceState: Bundle?) {
+        savedInstanceState?.getParcelable<Parcelable>(RECYCLER_VIEW_BUNDLE_KEY).let {
+            binding.listing.list.layoutManager?.onRestoreInstanceState(it)
+        }
+    }
+
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        if (!this::launches.isInitialized) {
-            setupList()
+        setupRecyclerView()
+
+        restoreRecyclerViewState(savedInstanceState)
+
+        fetchLaunches()
+    }
+
+    private fun setupRecyclerView() {
+        addSearchListeners()
+        setupFilterMenu()
+        hideNetworkError()
+        showSpinner()
+
+        // Add button press animation
+        adapter = LaunchOverviewAdapter(
+            LaunchClickListener(this::navigateToLaunchDetails),
+            this::setListHeaderText
+        )
+        binding.listing.list.adapter = adapter
+    }
+
+    private fun fetchLaunches() {
+        viewLifecycleOwner.lifecycleScope.launchWhenResumed {
+            val result = launchRepository.getLaunches()
+
+            if (!result.isNullOrEmpty()) {
+                setLaunchListing(result)
+                applySavedFilters()
+            } else {
+                showNetworkError()
+            }
         }
+    }
+
+    private fun applySavedFilters() {
+        val allFilters = SharedPreferencesManager.getListingFilterSetting(false)
+        allFilters?.forEach { (field, matches) ->
+            matches.forEach { match -> addAllFilter(field, match) }
+        }
+        val anyFilters = SharedPreferencesManager.getListingFilterSetting(true)
+        anyFilters?.forEach { (field, matches) ->
+            matches.forEach { match -> addAnyFilter(field, match) }
+        }
+    }
+
+    private fun setLaunchListing(launches: List<Launch?>) {
+        this.launches = launches.filterNotNull()
+        adapter.initializeList(this.launches)
+        setListHeaderText(launches.size)
+        hideSpinner()
     }
 
     private fun navigateToLaunchDetails(launch: Launch) {
@@ -171,35 +244,6 @@ class LandingPageFragment : Fragment() {
             popupMenu.show()
 
         }
-    }
-
-    private fun setupList() {
-        addSearchListeners()
-        setupFilterMenu()
-        hideNetworkError()
-        showSpinner()
-
-        // Add button press animation
-        adapter = LaunchOverviewAdapter(
-            LaunchClickListener(this::navigateToLaunchDetails),
-            this::setListHeaderText
-        )
-        binding.listing.list.adapter = adapter
-
-        viewLifecycleOwner.lifecycleScope.launchWhenResumed {
-
-            val result = launchRepository.getLaunches()
-            hideSpinner()
-
-            if (result != null) {
-                launches = result.filterNotNull()
-                adapter.initializeList(launches)
-                setListHeaderText(launches.size)
-            } else {
-                showNetworkError()
-            }
-        }
-
     }
 
     private fun hideKeyboardOnTouchOutside(event: MotionEvent) {

--- a/app/src/main/java/com/example/voyagerx/ui/fragments/landing/LandingPageFragment.kt
+++ b/app/src/main/java/com/example/voyagerx/ui/fragments/landing/LandingPageFragment.kt
@@ -57,19 +57,7 @@ class LandingPageFragment : Fragment() {
 
     private fun navigateToLaunchDetails(launch: Launch) {
         val bundle = Bundle()
-        bundle.apply {
-            LaunchDetailFields.let {
-                putString(it.id, launch.id)
-                putString(it.missionName, launch.mission_name)
-                putString(it.launchSite, launch.launch_site_long)
-                putString(it.launchDate, launch.launch_date_utc)
-                putString(it.launchYear, launch.launch_year)
-                putString(it.details, launch.details)
-                putString(it.articleLink, launch.article_link)
-                putString(it.videoLink, launch.video_link)
-                putStringArray(it.imageLinks, launch.image_links?.toTypedArray())
-            }
-        }
+        bundle.putParcelable(Launch.BUNDLE_KEY, launch)
 
         val launchDetailsFragment = LaunchDetailsFragment()
         launchDetailsFragment.arguments = bundle

--- a/app/src/main/java/com/example/voyagerx/ui/fragments/landing/list/LaunchOverviewAdapter.kt
+++ b/app/src/main/java/com/example/voyagerx/ui/fragments/landing/list/LaunchOverviewAdapter.kt
@@ -16,9 +16,9 @@ class LaunchOverviewAdapter(
     private var visibleLaunches: List<Launch> = listOf()
     private var allLaunches: List<Launch> = listOf()
     // map of an item field to a list of matches to filter on
-    private val filtersAnyMatch: MutableMap<String, MutableList<String>> = mutableMapOf()
-    private val filtersAllMatch: MutableMap<String, MutableList<String>> = mutableMapOf()
-    private var searchTerm: String = ""
+    val filtersAnyMatch: MutableMap<String, MutableList<String>> = mutableMapOf()
+    val filtersAllMatch: MutableMap<String, MutableList<String>> = mutableMapOf()
+    var searchTerm: String = ""
 
     fun initializeList(launches: List<Launch>) {
         allLaunches = launches

--- a/app/src/main/java/com/example/voyagerx/util/SharedPreferencesManager.kt
+++ b/app/src/main/java/com/example/voyagerx/util/SharedPreferencesManager.kt
@@ -3,9 +3,12 @@ package com.example.voyagerx.util
 import android.content.Context
 import android.content.SharedPreferences
 import android.util.Log
+import com.google.gson.Gson
+import com.google.gson.reflect.TypeToken
 
 class SharedPreferencesManager(val context: Context) {
-    private val sharedPref: SharedPreferences = context.getSharedPreferences(PREFERENCE_NAME, Context.MODE_PRIVATE)
+    private val sharedPref: SharedPreferences =
+        context.getSharedPreferences(PREFERENCE_NAME, Context.MODE_PRIVATE)
     private val editor = sharedPref.edit()
 
     private fun String.put(long: Long) {
@@ -33,9 +36,10 @@ class SharedPreferencesManager(val context: Context) {
     private fun String.getString() = sharedPref.getString(this, "")!!
     private fun String.getBoolean() = sharedPref.getBoolean(this, true)
 
-    fun setBackgroundWallpaper(wallpaperSelection: Boolean) = PREF_BKG_APPEARANCE.put(wallpaperSelection)
+    fun setBackgroundWallpaper(wallpaperSelection: Boolean) =
+        PREF_BKG_APPEARANCE.put(wallpaperSelection)
 
-    fun getBackgroundWallpaper() : Boolean {
+    fun getBackgroundWallpaper(): Boolean {
         PREF_BKG_APPEARANCE.getBoolean()
         Log.d("appearance switch", PREF_BKG_APPEARANCE.getBoolean().toString())
         return PREF_BKG_APPEARANCE.getBoolean()
@@ -43,7 +47,7 @@ class SharedPreferencesManager(val context: Context) {
 
     fun setTextInDropdown(dropDownText: String) = PREF_DROP_DOWN_TEXT.put(dropDownText)
 
-    fun getTextInDropdown() : String {
+    fun getTextInDropdown(): String {
         PREF_DROP_DOWN_TEXT.getString()
         Log.d("font size drop dwn text", PREF_DROP_DOWN_TEXT.getString())
         return PREF_DROP_DOWN_TEXT.getString()
@@ -52,21 +56,42 @@ class SharedPreferencesManager(val context: Context) {
     //to be updated later if styles are used
     fun setTextSize(fontSize: String) = PREF_FONT_SIZE.put(fontSize)
 
-    fun getFontSize() : String {
+    fun getFontSize(): String {
         PREF_FONT_SIZE.getString()
         Log.d("font size value", PREF_FONT_SIZE.getBoolean().toString())
         return PREF_FONT_SIZE.getString()
     }
 
-    fun setLaunchNotifications(notificationSelection : Boolean) = PREF_LAUNCH_NOTIFICATIONS.put(notificationSelection)
+    fun setLaunchNotifications(notificationSelection: Boolean) =
+        PREF_LAUNCH_NOTIFICATIONS.put(notificationSelection)
 
-    fun getLaunchNotifications() : Boolean {
+    fun getLaunchNotifications(): Boolean {
         PREF_LAUNCH_NOTIFICATIONS.getBoolean()
         Log.d("notification switch", PREF_LAUNCH_NOTIFICATIONS.getBoolean().toString())
         return PREF_LAUNCH_NOTIFICATIONS.getBoolean()
     }
 
+    fun setListingFilterSetting(
+        isAnyFilter: Boolean,
+        value: MutableMap<String, MutableList<String>>,
+    ) {
+        val json = Gson().toJson(value)
+        if (isAnyFilter) {
+            PREF_LAUNCH_FILTER_ANY.put(json)
+        } else {
+            PREF_LAUNCH_FILTER_ALL.put(json)
+        }
+    }
 
+    fun getListingFilterSetting(isAnyFilter: Boolean): MutableMap<String, MutableList<String>>? {
+        val json =
+            if (isAnyFilter) PREF_LAUNCH_FILTER_ANY.getString() else PREF_LAUNCH_FILTER_ALL.getString()
+        if (json.isNotBlank()) {
+            return Gson().fromJson(json,
+                object : TypeToken<MutableMap<String, MutableList<String>>>() {}.type)
+        }
+        return null
+    }
 
     companion object {
         const val PREFERENCE_NAME = "SHARED_PREFS"
@@ -74,6 +99,8 @@ class SharedPreferencesManager(val context: Context) {
         const val PREF_FONT_SIZE = "PREF_FONT_SIZE"
         const val PREF_DROP_DOWN_TEXT = "PREF_DROP_DOWN_TEXT"
         const val PREF_LAUNCH_NOTIFICATIONS = "PREF_LAUNCH_NOTIFICATIONS"
+        const val PREF_LAUNCH_FILTER_ANY = "PREF_LAUNCH_FILTER_ANY"
+        const val PREF_LAUNCH_FILTER_ALL = "PREF_LAUNCH_FILTER_ALL"
     }
 
 }

--- a/app/src/main/res/layout/fragment_landing_page.xml
+++ b/app/src/main/res/layout/fragment_landing_page.xml
@@ -25,6 +25,7 @@
         layout="@layout/landing_page_error"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
+        android:visibility="invisible"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />

--- a/app/src/main/res/layout/landing_page_launch_listing.xml
+++ b/app/src/main/res/layout/landing_page_launch_listing.xml
@@ -39,6 +39,7 @@
 
             <com.google.android.material.progressindicator.CircularProgressIndicator
                 android:id="@+id/spinner"
+                android:visibility="invisible"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:indeterminate="true"

--- a/app/src/main/res/layout/landing_page_launch_listing.xml
+++ b/app/src/main/res/layout/landing_page_launch_listing.xml
@@ -2,6 +2,7 @@
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/landing_page_layout"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
@@ -17,6 +18,7 @@
         app:layout_constraintTop_toTopOf="parent">
 
         <androidx.constraintlayout.widget.ConstraintLayout
+            android:id="@+id/landing_page_card_layout"
             android:layout_width="match_parent"
             android:layout_height="match_parent">
 


### PR DESCRIPTION
This will persist the landing page's recycler view position/filter settings across navigation changes and when the fragment is destroyed/re-created.

I ended up changing the landing page fragment used in MainActivity to try to use the same instance when possible.
My thinking was that this would preserve the recycler view scroll position and search text more easily when switching between fragments during navigation instead of trying to save them using a shared preference.

I still used a bundle to save the position during onSaveInstanceState after orientation changes since the fragment is destroyed. I'm also using shared preferences in both situations to save the filter state.

https://user-images.githubusercontent.com/15068593/167499164-28f3a73e-0364-4c8c-bd30-6c67eb6b7fcb.mov