### PR TITLE
added paranthesis

### DIFF
--- a/app/src/main/java/com/example/voyagerx/presenters/LaunchDetailsPresenter.kt
+++ b/app/src/main/java/com/example/voyagerx/presenters/LaunchDetailsPresenter.kt
@@ -60,13 +60,14 @@ class LaunchDetailsPresenter(private var userRepository: UserRepository, var vie
     }
 
     fun shareLaunch() {
+        Log.d("user", launchObj.toString())
         val share = Intent.createChooser(Intent().apply {
             action = Intent.ACTION_SEND
             putExtra(
                 Intent.EXTRA_TEXT, "Check out this SpaceX Launch!\n\n" +
-                        if (!launchObj.mission_name.isNullOrEmpty()) "${launchObj.mission_name}\n\n" else "" +
-                                if (!launchObj.details.isNullOrEmpty()) "${launchObj.details}\n\n" else "" +
-                                        if (!launchObj.video_link.isNullOrEmpty()) "Watch the launch video:\n ${launchObj.video_link}" else ""
+                        (if (!launchObj.mission_name.isNullOrEmpty()) "${launchObj.mission_name}\n\n" else "") +
+                        (if (!launchObj.details.isNullOrEmpty()) "${launchObj.details}\n\n" else "") +
+                        (if (!launchObj.video_link.isNullOrEmpty()) "Watch the launch video:\n ${launchObj.video_link}" else "")
             )
             type = "text/plain"
         }, null)


### PR DESCRIPTION
The shared message wasn't including the launch details or the video link. Turns out I was missing a few parenthesis 🙃 

https://onramp-training.atlassian.net/browse/TA2-105

![Screen Shot 2022-05-10 at 3 30 44 PM](https://user-images.githubusercontent.com/41392379/167716930-fcd260d4-43bb-4486-a612-75676e95f82c.png)
