### PR TITLE
limiting database calls

### DIFF
--- a/app/src/main/java/com/example/voyagerx/ui/fragments/editprofile/EditProfileFragment.kt
+++ b/app/src/main/java/com/example/voyagerx/ui/fragments/editprofile/EditProfileFragment.kt
@@ -95,31 +95,32 @@ class EditProfileFragment : Fragment() {
             binding.editLocationField.text = usersLocation.toString().toEditable()
         }
 
-        updateInfoInDatabase()
-
+        if (currentUser != null) {
+            updateInfoInDatabase(currentUser)
+        }
     }
 
 
 
-    private fun updateInfoInDatabase() {
+    private fun updateInfoInDatabase(user: User) {
         val newUserDetails = User(
-            userRepository.getCurrentUser()?.id!!.toInt(),
-            userRepository.getCurrentUser()?.email.toString(),
-            userRepository.getCurrentUser()?.password.toString(),
-            userRepository.getCurrentUser()?.name.toString(),
-            userRepository.getCurrentUser()?.location.toString(),
-            userRepository.getCurrentUser()?.bio.toString(),
-            userRepository.getCurrentUser()?.favoriteLaunches
+            user.id,
+            user.email,
+            user.password,
+            user.name,
+            user.location,
+            user.bio,
+            user.favoriteLaunches
         )
 
         binding.btnSave.setOnClickListener {
-            if ((userRepository.getCurrentUser()?.name) != binding.editNameField.text.toString()) {
+            if ((user.name) != binding.editNameField.text.toString()) {
                 newUserDetails.name = binding.editNameField.text.toString()
             }
-            if ((userRepository.getCurrentUser()?.bio) != binding.editBio.text.toString()) {
+            if ((user.bio) != binding.editBio.text.toString()) {
                 newUserDetails.bio = binding.editBio.text.toString()
             }
-            if ((userRepository.getCurrentUser()?.location) != binding.editLocationField.text.toString()) {
+            if ((user.location) != binding.editLocationField.text.toString()) {
                 newUserDetails.location = binding.editLocationField.text.toString()
             }
 


### PR DESCRIPTION
This ticket updates the code in the Edit Profile fragment to limit the amount of database calls by creating an object with the current user's info and then accessing that object's fields, rather than making separate database calls for each individual piece of data requested (name, location, or bio).

https://onramp-training.atlassian.net/jira/software/projects/TA2/boards/22?selectedIssue=TA2-109