### PR TITLE
Fixing keyboard focus bug

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -18,7 +18,8 @@
         </activity>
         <activity
             android:name=".MainActivity"
-            android:exported="true">
+            android:exported="true"
+            android:windowSoftInputMode="adjustPan">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 


### PR DESCRIPTION
There is a "sometimes" bug that I believe occurs the first time the app is run in the emulator. 

Per [this](https://developer.android.com/reference/android/R.attr.html#windowSoftInputMode) doc, adding adjustPan to the Manifest so the user can see the contents of what they're typing without being obstructed by the BottomNavigation bar or keyboard.

Video showing the bottom navigation bar moving and obstructing the edit profile fields:

https://user-images.githubusercontent.com/103965030/168184391-c7511e0f-e8fd-45dc-86b6-cfc4246b956e.mov






 